### PR TITLE
ReleaseCommand: now it is possible to release a version that is lower than the newest one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "symplify/monorepo-builder",
-    "description": "Not only Composer tools to build a Monorepo.",
+    "name": "shopsys/monorepo-builder",
+    "description": "[FORK] Not only Composer tools to build a Monorepo.",
     "license": "MIT",
     "bin": [
         "bin/monorepo-builder"

--- a/packages/Release/src/Guard/ReleaseGuard.php
+++ b/packages/Release/src/Guard/ReleaseGuard.php
@@ -134,7 +134,7 @@ final class ReleaseGuard
         }
 
         throw new InvalidGitVersionException(sprintf(
-            'Provided version "%s" must be never than the last one: "%s"',
+            'Provided version "%s" is lower than the last one: "%s"',
             $version->getVersionString(),
             $mostRecentVersion->getVersionString()
         ));


### PR DESCRIPTION
- it is necessary when supporting multiple versions of your application
- e.g. the newest tag is "v8.0.0" and you want to release "v7.3.2"