### PR TITLE
fix: sanitize secrets from process output

### DIFF
--- a/packages/Split/src/Git/GitManager.php
+++ b/packages/Split/src/Git/GitManager.php
@@ -73,6 +73,19 @@ final class GitManager
     }
 
     /**
+     * Sanitize secrets from process output to ensure they are not
+     * exposed in CI logs
+     *
+     * @param string $output
+     *
+     * @return string
+     */
+    public function sanitizeProcessOutput(string $output): string
+    {
+        return Strings::replace($output, $this->githubToken, '***');
+    }
+
+    /**
      * @param string $commandResult
      * @return string[]
      */

--- a/packages/Split/src/PackageToRepositorySplitter.php
+++ b/packages/Split/src/PackageToRepositorySplitter.php
@@ -117,7 +117,7 @@ final class PackageToRepositorySplitter
                 $message = sprintf(
                     'Process failed with "%d" code: "%s"',
                     $process->getExitCode(),
-                    $process->getErrorOutput()
+                    $this->gitManager->sanitizeProcessOutput($process->getErrorOutput())
                 );
 
                 throw new PackageToRepositorySplitException($message);
@@ -129,7 +129,7 @@ final class PackageToRepositorySplitter
                     $processInfo->getLocalDirectory(),
                     $processInfo->getRemoteRepository(),
                     PHP_EOL . PHP_EOL,
-                    $process->getOutput()
+                    $this->gitManager->sanitizeProcessOutput($process->getOutput())
                 )
             );
         }


### PR DESCRIPTION
As it currently stands if you use the `split` command in a CI environment the github token is exposed in the logs.

Example of a build with this issue: (token revoked)
https://github.com/atymic/Providers/commit/978ddc88ff75d52e910ea007376f15d4977fe697/checks?check_suite_id=301041414

This PR adds a step before we output the subsplit output to remove any instances of the github token from it.